### PR TITLE
[SO_ARP_MJPNL_20201026] Eliminierung Ungereimtheiten

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -603,9 +603,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Schnittgut trocknen, abführen o. v. Ort aufhäufen"
       Bewirtschaftung_Schnittgut_trocknen_lassen : MANDATORY BOOLEAN;
-      /** Bewirtschaftungs- und Pflegemassnahmen; Abgeltung per ha in CHF.
+      /** Bewirtschaftungs- und Pflegemassnahmen; Abgeltung per Hektar in CHF.
        */
-      !!@ ili2db.dispName = "Bewirtschaftungs- / Pflegemassnahmen; Abgeltung per ha"
+      !!@ ili2db.dispName = "Bewirtschaftungs- / Pflegemassnahmen; Abgeltung per Hektar"
       Bewirtschaftung_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Dornenreiche dichte einreihige Strauchgruppen nach Absprache anlegen (keine Hecken). Rückschnitt nach Bedarf und in gegenseitiger Absprache.
        * Bestellung und Kosten für das Pflanzgut übernimmt das ARP.
@@ -656,9 +656,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Abgeltung total per Hektar"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1000.00 [Units.CHF];
-      /** Abgeltung Fläche total (Abgeltung per ha x ha)
+      /** Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)
        */
-      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per ha x ha)"
+      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 20000.00;
       /** Abgeltung pauschal total
        */
@@ -675,9 +675,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Massnahmengebiet Förderung von Feldhasen und Feldlerchen"
       Einstiegskriterium_Massnahmengebiet_FeldhasenLerchen : MANDATORY BOOLEAN;
-      /** Betrieb verfügt über mind. 1.5 ha offene Ackerfläche in FFF.
+      /** Betrieb verfügt über mind. 1.5 Hektar offene Ackerfläche in FFF.
        */
-      !!@ ili2db.dispName = "Mind. 1.5 ha offene Ackerfläche in FFF."
+      !!@ ili2db.dispName = "Mind. 1.5 Hektar offene Ackerfläche in FFF."
       Einstiegskriterium_min_Ackerflaeche : MANDATORY BOOLEAN;
       /** Nicht längsseitig entlang von Flurwegen. In der Regel mind. 30 Meter von Wegen mit Hartbelag entfernt.
        */
@@ -739,9 +739,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Schnittgut trocknen, abführen o. v. Ort aufhäufen"
       Bewirtschaftung_Schnittgut_trocknen_lassen : MANDATORY BOOLEAN;
-      /** Bewirtschaftungs- und Pflegemassnahmen; Abgeltung per ha in CHF.
+      /** Bewirtschaftungs- und Pflegemassnahmen; Abgeltung per Hektar in CHF.
        */
-      !!@ ili2db.dispName = "Bewirtschaftungs- / Pflegemassnahmen; Abgeltung per ha"
+      !!@ ili2db.dispName = "Bewirtschaftungs- / Pflegemassnahmen; Abgeltung per Hektar"
       Bewirtschaftung_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Dornenreiche dichte einreihige Strauchgruppen nach Absprache anlegen (keine Hecken). Rückschnitt nach Bedarf und in gegenseitiger Absprache.
        * Bestellung und Kosten für das Pflanzgut übernimmt das ARP.
@@ -784,9 +784,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Abgeltung total per Hektar"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1000.00 [Units.CHF];
-      /** Abgeltung Fläche total (Abgeltung per ha x ha)
+      /** Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)
        */
-      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per ha x ha)"
+      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 20000.00 [Units.CHF];
       /** Abgeltung pauschal total
        */
@@ -827,7 +827,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Einstiegskriterium BFF Stufe I & II sind erfüllt"
       Einstiegskriterium_BFF_Stufe_I_II_erfuellt : MANDATORY BOOLEAN;
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Faunabonus Anzahl Arten.
        */
@@ -837,42 +837,42 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Artenvielfalt total (max. CHF 150.- pauschal)"
       Faunabonus_Artenvielfalt_Abgeltung_pauschal : 0.00 .. 150.00 [Units.CHF];
-      /** Ab 10 Strauch- und Baumarten auf 10m Länge oder grosser Anteil an Dornensträuchern (mehr als 30%), CHF 100.- pro ha.
+      /** Ab 10 Strauch- und Baumarten auf 10m Länge oder grosser Anteil an Dornensträuchern (mehr als 30%), CHF 100.- per Hektar.
        */
       !!@ ili2db.dispName = "10 Strauch/Baumarten auf 10m Länge oder gr. Anteil Dornensträucher"
       EinstufungBeurteilungIstZustand_Artenvielfalt_Strauch_Baumarten : MANDATORY BOOLEAN;
-      /** Asthaufen (2x2x1m / grösser), min. 1 pro 20 Aren, CHF 100.- pro ha.
+      /** Asthaufen (2x2x1m / grösser), min. 1 per 20 Aren, CHF 100.- per Hektar.
        */
-      !!@ ili2db.dispName = "Asthaufen (2x2x1m / grösser), min. 1 pro 20 Aren"
+      !!@ ili2db.dispName = "Asthaufen (2x2x1m / grösser), min. 1 per 20 Aren"
       EinstufungBeurteilungIstZustand_Asthaufen : MANDATORY BOOLEAN;
-      /** Liegendes Totholz ? 1m lang (Ø ? 30 cm). CHF 50.- pro ha.
+      /** Liegendes Totholz ? 1m lang (Ø ? 30 cm). CHF 50.- per Hektar.
        */
       !!@ ili2db.dispName = "Liegendes Totholz ? 1m lang (Ø ? 30 cm)"
       EinstufungBeurteilungIstZustand_Totholz : MANDATORY BOOLEAN;
-      /** Steinhaufen (Ø Steingrösse ? 15cm) min. 2 x 2 x 1m und -0,5m in Boden versenken (Frostfreiezone). CHF 150.- pro ha.
+      /** Steinhaufen (Ø Steingrösse ? 15cm) min. 2 x 2 x 1m und -0,5m in Boden versenken (Frostfreiezone). CHF 150.- per Hektar.
        */
       !!@ ili2db.dispName = "Steinhaufen (Ø Steingrösse ? 15cm) min. 2 x 2 x 1m"
       EinstufungBeurteilungIstZustand_Steinhaufen : MANDATORY BOOLEAN;
-      /** Schichtholzbeigen (1x1x1m) mit hohem Laubholzanteil. CHF 150.- pro ha.
+      /** Schichtholzbeigen (1x1x1m) mit hohem Laubholzanteil. CHF 150.- per Hektar.
        */
       !!@ ili2db.dispName = "Schichtholzbeigen (1x1x1m) mit hohem Laubholzanteil"
       EinstufungBeurteilungIstZustand_Schichtholzbeigen : BOOLEAN;
-      /** Nisthilfe für erdbewohnende Wildbienen (z.B Steinburgen/-bette mit Wandsand, Sand mit hohem Silt/ Tongehalt, gefüllt). CHF 200.- pro ha.
+      /** Nisthilfe für erdbewohnende Wildbienen (z.B Steinburgen/-bette mit Wandsand, Sand mit hohem Silt/ Tongehalt, gefüllt). CHF 200.- per Hektar.
        */
       !!@ ili2db.dispName = "Nisthilfe für erdbewohnende Wildbienen"
       EinstufungBeurteilungIstZustand_Nisthilfe_Wildbienen : MANDATORY BOOLEAN;
       /** Höhlenbäume, Biotopbäume, stehendes Totholz 
-       * oder mit Efeu behangene Bäume, Weichhölzer, wertvolle Laubbäume (wie Eiche, Feldahorn, Traubenkirsche etc.) nach Absprache fördern und erhalten. CHF 100.- pro ha.
+       * oder mit Efeu behangene Bäume, Weichhölzer, wertvolle Laubbäume (wie Eiche, Feldahorn, Traubenkirsche etc.) nach Absprache fördern und erhalten. CHF 100.- per Hektar.
        */
       !!@ ili2db.dispName = "Höhlenbäume, Biotopbäume, stehendes Totholz"
       EinstufungBeurteilungIstZustand_Hoehlenbaeume_Biotopbaeume_Totholz : MANDATORY BOOLEAN;
-      /** Sitzwarte (in Niederhecken). CHF 25.- pro ha.
+      /** Sitzwarte (in Niederhecken). CHF 25.- per Hektar.
        */
       !!@ ili2db.dispName = "Sitzwarte (in Niederhecken)"
       EinstufungBeurteilungIstZustand_Sitzwarte : MANDATORY BOOLEAN;
       /** Einstufung / Beurteilung Ist-Zustand - Abgeltung total.
        */
-      !!@ ili2db.dispName = "Einstufung / Beurteilung Ist-Zustand - Abgeltung per ha total"
+      !!@ ili2db.dispName = "Einstufung / Beurteilung Ist-Zustand - Abgeltung per Hektar total"
       EinstufungBeurteilungIstZustand_Abgeltung_ha : MANDATORY 0.00 .. 800.00 [Units.CHF];
       /** Heckentypen sind kombinierbar und die Übergänge sind oft fliessend. Keine separate Abgeltung.
        */
@@ -900,14 +900,14 @@ VERSION "2020-10-26"  =
       Bewirtschaftung_Hecke_LetzterUnterhalt : 1900 .. 2100;
       !!@ ili2db.dispName = "Anteil der zu bewirtschaftenden Fläche"
       Bewirtschaftung_Hecke_UnterhaltAnteil : Bewirtschaftung_Anteile;
-      /** Der Krautsaum wird max. 2-mal jährlich geschnitten, erste Hälfte ab 15. Juni, zweite Hälfte frühestens 6 Wochen später (gestaffelt nie vollständig mähen) 1/2 alternierend mähen. Der Krautsaum bleibt über den Winter stehen. CHF 300.- pro ha.
+      /** Der Krautsaum wird max. 2-mal jährlich geschnitten, erste Hälfte ab 15. Juni, zweite Hälfte frühestens 6 Wochen später (gestaffelt nie vollständig mähen) 1/2 alternierend mähen. Der Krautsaum bleibt über den Winter stehen. CHF 300.- per Hektar.
        */
       !!@ ili2db.dispName = "Bewirtschaftung Krautsaum"
       !!@ Abgeltungsart="per_ha"
       !!@ Abgeltung="300"
       Bewirtschaftung_Krautsaum : MANDATORY BOOLEAN;
       /** Anpassung der Schnittzeitpunkte bei seltenen Arten im
-       * Krautsaum. CHF 100.- pro ha.
+       * Krautsaum. CHF 100.- per Hektar.
        */
       !!@ ili2db.dispName = "Anpassung der Schnittzeitpunkte bei seltenen Arten"
       Bewirtschaftung_Krautsaum_Schnittzeitpunkte : MANDATORY BOOLEAN;
@@ -919,7 +919,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "2. Schnit Krautsaum"
       Bewirtschaftung_Krautsaum_Schnittzeitpunkt_2 : FORMAT INTERLIS.XMLDate "1900-1-1" .. "2099-12-31";
-      /** Offener Boden schaffen entlang Krautsaum max. 10% der Krautsaumfläche, erst möglich bei mehr als 3m breitem Krautsaum. CHF 300.- pro ha.
+      /** Offener Boden schaffen entlang Krautsaum max. 10% der Krautsaumfläche, erst möglich bei mehr als 3m breitem Krautsaum. CHF 300.- per Hektar.
        */
       !!@ ili2db.dispName = "Offener Boden"
       Bewirtschaftung_Krautsaum_Offener_Boden : MANDATORY BOOLEAN;
@@ -931,16 +931,16 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Beweidung des Krautsaums nach Absprache"
       Bewirtschaftung_Krautsaum_Beweidung_nach_Absprache : MANDATORY BOOLEAN;
-      /** Bewirtschaftung Krautsaum Abgeltung total (per ha)
+      /** Bewirtschaftung Krautsaum Abgeltung total (per Hektar)
        */
-      !!@ ili2db.dispName = "Bewirtschaftung Krautsaum Abgeltung per ha total"
+      !!@ ili2db.dispName = "Bewirtschaftung Krautsaum Abgeltung per Hektar total"
       Bewirtschaftung_Krautsaum_Abgeltung_ha : MANDATORY 0.00 .. 700.00 [Units.CHF];
       /** Der Lebhag wird jährlich, auf allen Seiten, zurückgeschnitten. 
        * Der Schnitt erfolgt in der Vegetationsruhe von Oktober - Februar.
        */
       !!@ ili2db.dispName = "Laufmeter Lebhag"
       Bewirtschaftung_Lebhag_Laufmeter : 0 .. 3000 [INTERLIS.m];
-      /** pro Laufmeter und Seite CHF 1.50 (Pauschalbetrag (nicht per ha)).
+      /** pro Laufmeter und Seite CHF 1.50 (Pauschalbetrag (nicht per Hektar)).
        */
       !!@ ili2db.dispName = "Abgeltung Schnitt/Pflege"
       Bewirtschaftung_Lebhag_Abgeltung_pauschal : 0.00 .. 6000.00 [Units.CHF];
@@ -955,9 +955,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 100 CHF pro ha).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 100 CHF per Hektar).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -969,9 +969,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 100 CHF pro ha).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 100 CHF per Hektar).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 3
        */
@@ -983,13 +983,13 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 3 Beschreibung"
       Erschwernis_Massnahme3_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 3 Abgeltung (max. 100 CHF pro ha).
+      /** Erschwernis Massnahme 3 Abgeltung (max. 100 CHF per Hektar).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung per Hektar"
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Massnahmen Abgeltung total (per ha).
+      /** Erschwernis aufwendige Handarbeit Massnahmen Abgeltung total (per Hektar).
        */
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Abgeltung total per Hektar
        */
@@ -997,7 +997,7 @@ VERSION "2020-10-26"  =
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 2000.00 [Units.CHF];
       /** Abgeltung Fläche total (Betrag x ha).
        */
-      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per ha x ha)"
+      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 20000.00 [Units.CHF];
       /** Abgeltung total pauschal
        */
@@ -1149,9 +1149,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Kein Einsatz von Wieseneggen, Striegel und Walzen"
       Einstiegskriterium_KeinEinsatzWieseneggenStriegelWalzen : MANDATORY BOOLEAN;
-      /** Einstiegskriterium Abgeltung in CHF per ha
+      /** Einstiegskriterium Abgeltung in CHF per Hektar
        */
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       /** Zeigerarten gemäss Floraliste: Nährstoffzeiger (- Arten)
        */
@@ -1179,9 +1179,9 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Abgeltung_Faunaliste_pauschal : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Weiden Kat. (Art / Typ), Grundlagen: Floraliste"
       EinstufungBeurteilungIstZustand_Weidenkategorie : MANDATORY Weidenkategorie;
-      /** Bis max Fr. 200.- pro ha
+      /** Bis max Fr. 200.- per Hektar
        */
-      !!@ ili2db.dispName = "Abgeltung Weidenkategorie pro ha"
+      !!@ ili2db.dispName = "Abgeltung Weidenkategorie per Hektar"
       EinstufungBeurteilungIstZustand_Weidenkategorie_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Weidenstruktur: optimal, beibehalten
        */
@@ -1195,9 +1195,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Struktur - Verbuschung, Eingriff nötig"
       EinstufungBeurteilungIstZustand_Struktur_Verbuschung_Eingriff_noetig : MANDATORY BOOLEAN;
-      /** Bei optimaler Struktur bis Fr. 100.- pro ha
+      /** Bei optimaler Struktur bis Fr. 100.- per Hektar
        */
-      !!@ ili2db.dispName = "Abgeltung Struktur pro ha"
+      !!@ ili2db.dispName = "Abgeltung Struktur per Hektar"
       EinstufungBeurteilungIstZustand_Struktur_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       !!@ ili2db.dispName = "Bodeneigenschaften"
       !!@ ili2db.mapping="ARRAY"
@@ -1208,9 +1208,9 @@ VERSION "2020-10-26"  =
       !!@ ili2db.dispName = "Besondere Strukturen"
       !!@ ili2db.mapping="ARRAY"
       EinstufungBeurteilungIstZustand_BesondereStrukturen : BAG {0..*} OF Weide_BesondereStrukturen_;
-      /** pro ha / Jahr
+      /** per Hektar / Jahr
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung per Hektar"
       EinstufungBeurteilungIstZustand_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Beweidung mit Rindern
        */
@@ -1252,9 +1252,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -1264,13 +1264,13 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
+      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
        */
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1290,11 +1290,11 @@ VERSION "2020-10-26"  =
       Artenfoerderung_FF_Zielart3_Massnahme : MTEXT*1000;
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 3 Abgeltung"
       Artenfoerderung_FF_Zielart3_Abgeltung : MANDATORY 0.00 .. 100.00 [Units.CHF];
-      /** Abgeltungsart per ha oder pauschal
+      /** Abgeltungsart per Hektar oder pauschal
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltungsart"
       Artenfoerderung_Abgeltungsart : MANDATORY Abgeltungsart;
-      /** Abgeltung Artenförderung total (pauschal max 300 oder per ha max 300)
+      /** Abgeltung Artenförderung total (pauschal max 300 oder per Hektar max 300)
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -1395,9 +1395,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Einstiegskriterium - Bodenheu"
       Einstiegskriterium_Bodenheu : MANDATORY BOOLEAN;
-      /** Einstiegskriterium Abgeltung in CHF per ha
+      /** Einstiegskriterium Abgeltung in CHF per Hektar
        */
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Zeigerarten gemäss Floraliste: Nährstoffzeiger (- Arten)
        */
@@ -1425,7 +1425,7 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Abgeltung_Faunaliste_pauschal : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Heumatten Kat. (Art / Typ), Grundlagen: Floraliste"
       EinstufungBeurteilungIstZustand_Wiesenkategorie : MANDATORY Wiesenkategorie;
-      /** Abgeltung Wiesenkategorie per ha (abhängig von gewählter Wiesenkategorie)
+      /** Abgeltung Wiesenkategorie per Hektar (abhängig von gewählter Wiesenkategorie)
        * 
        * Kat_RF: 0 - 0
        * Kat_RF_II: 100 - 100
@@ -1433,7 +1433,7 @@ VERSION "2020-10-26"  =
        * Kat_II_artenreicheWiese: 400 - 500
        * Kat_I_besondersartenreicheWiese: 600 - 800
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Wiesenkategorie pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Wiesenkategorie per Hektar"
       EinstufungBeurteilungIstZustand_Wiesenkategorie_Abgeltung_ha : MANDATORY 0.00 .. 800.00 [Units.CHF];
       !!@ ili2db.dispName = "Exposition"
       EinstufungBeurteilungIstZustand_LageWiese_Exposition : Exposition;
@@ -1475,7 +1475,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Mähen mit Messerbalken-Mähgerät"
       BewirtschaftAbmachung_MesserbalkenMaehgeraet : MANDATORY BOOLEAN;
-      /** maximal 350 CHF pro ha/Jahr
+      /** maximal 350 CHF per Hektar/Jahr
        */
       !!@ ili2db.dispName = "Abgeltung Bewirtschaftungsabmachung"
       BewirtschaftAbmachung_Abgeltung_ha : MANDATORY 0.00 .. 350.00 [Units.CHF];
@@ -1487,9 +1487,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -1499,11 +1499,11 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1525,7 +1525,7 @@ VERSION "2020-10-26"  =
       Artenfoerderung_FF_Zielart3_Abgeltung : MANDATORY 0.00 .. 100.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Abgeltungsart"
       Artenfoerderung_Abgeltungsart : MANDATORY Abgeltungsart;
-      /** Abgeltung Artenförderung total (pauschal max 300 oder per ha max 300)
+      /** Abgeltung Artenförderung total (pauschal max 300 oder per Hektar max 300)
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -1631,7 +1631,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Einstiegskriterium Kein Einsatz von Wieseneggen, Striegel und Walzen"
       Einstiegskriterium_KeinEinsatzWieseneggenStriegelWalzen : MANDATORY BOOLEAN;
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : 0.00 .. 100.00 [Units.CHF];
       /** Zeigerarten gemäss Floraliste: Nährstoffzeiger (- Arten)
        */
@@ -1659,9 +1659,9 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Abgeltung_Faunaliste_pauschal : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Weiden Kat. (Art / Typ), Grundlagen: Floraliste"
       EinstufungBeurteilungIstZustand_Weidenkategorie : MANDATORY Weidenkategorie;
-      /** Bis max Fr. 200.- pro ha
+      /** Bis max Fr. 200.- per Hektar
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Weidenkategorie pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Weidenkategorie per Hektar"
       EinstufungBeurteilungIstZustand_Weidenkategorie_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Weidenstruktur: optimal, beibehalten
        */
@@ -1675,9 +1675,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Struktur - Verbuschung, Eingriff nötig"
       EinstufungBeurteilungIstZustand_Struktur_Verbuschung_Eingriff_noetig : MANDATORY BOOLEAN;
-      /** Bei optimaler Struktur bis Fr. 100.- pro ha
+      /** Bei optimaler Struktur bis Fr. 100.- per Hektar
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Struktur pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Struktur per Hektar"
       EinstufungBeurteilungIstZustand_Struktur_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       !!@ ili2db.mapping="ARRAY"
       EinstufungBeurteilungIstZustand_Bodeneigenschaften : BAG {0..*} OF Bodeneigenschaft_;
@@ -1686,9 +1686,9 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Weidnarbe : BAG {0..*} OF Weidnarbe_;
       !!@ ili2db.mapping="ARRAY"
       EinstufungBeurteilungIstZustand_BesondereStrukturen : BAG {0..*} OF Weide_BesondereStrukturen_;
-      /** pro ha / Jahr
+      /** per Hektar / Jahr
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung per Hektar"
       EinstufungBeurteilungIstZustand_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Beweidung mit Rindern
        */
@@ -1726,9 +1726,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -1738,9 +1738,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 3
        */
@@ -1750,13 +1750,13 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 3 Beschreibung"
       Erschwernis_Massnahme3_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 3 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 3 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung per Hektar"
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
+      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
        */
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1776,11 +1776,11 @@ VERSION "2020-10-26"  =
       Artenfoerderung_FF_Zielart3_Massnahme : MTEXT*1000;
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 3 Abgeltung"
       Artenfoerderung_FF_Zielart3_Abgeltung : MANDATORY 0.00 .. 100.00 [Units.CHF];
-      /** Abgeltungsart per ha oder pauschal
+      /** Abgeltungsart per Hektar oder pauschal
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltungsart"
       Artenfoerderung_Abgeltungsart : MANDATORY Abgeltungsart;
-      /** Abgeltung Artenförderung total (pauschal max 300 oder per ha max 250)
+      /** Abgeltung Artenförderung total (pauschal max 300 oder per Hektar max 250)
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -1825,9 +1825,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Einstiegskriterium Kein Einsatz von Wieseneggen, Striegel und Walzen"
       Einstiegskriterium_KeinEinsatzWieseneggenStriegelWalzen : MANDATORY BOOLEAN;
-      /** Einstiegskriterium Abgeltung pro ha (max. 100 CHF)
+      /** Einstiegskriterium Abgeltung per Hektar (max. 100 CHF)
        */
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       /** Zeigerarten gemäss Floraliste: Nährstoffzeiger (- Arten)
        */
@@ -1855,9 +1855,9 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Abgeltung_Faunaliste_pauschal : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Weiden Kat. (Art / Typ), Grundlagen: Floraliste"
       EinstufungBeurteilungIstZustand_Weidenkategorie : MANDATORY Weidenkategorie;
-      /** Bis max Fr. 300.- pro ha
+      /** Bis max Fr. 300.- per Hektar
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Weidenkategorie pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Weidenkategorie per Hektar"
       EinstufungBeurteilungIstZustand_Weidenkategorie_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Weidenstruktur: optimal, beibehalten
        */
@@ -1871,9 +1871,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Struktur - Verbuschung, Eingriff nötig"
       EinstufungBeurteilungIstZustand_Struktur_Verbuschung_Eingriff_noetig : MANDATORY BOOLEAN;
-      /** Bei optimaler Struktur bis Fr. 150.- pro ha
+      /** Bei optimaler Struktur bis Fr. 150.- per Hektar
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Struktur pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung Struktur per Hektar"
       EinstufungBeurteilungIstZustand_Struktur_Abgeltung_ha : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Bodeneigenschaften"
       !!@ ili2db.mapping="ARRAY"
@@ -1883,9 +1883,9 @@ VERSION "2020-10-26"  =
       !!@ ili2db.dispName = "Besondere Strukturen"
       !!@ ili2db.mapping="ARRAY"
       EinstufungBeurteilungIstZustand_BesondereStrukturen : BAG {0..*} OF Weide_BesondereStrukturen_;
-      /** pro ha / Jahr
+      /** per Hektar / Jahr
        */
-      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Abgeltung per Hektar"
       EinstufungBeurteilungIstZustand_Abgeltung_ha : MANDATORY 0.00 .. 450.00 [Units.CHF];
       /** Beweidung mit Rindern
        */
@@ -1923,9 +1923,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -1934,9 +1934,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 3
        */
@@ -1945,13 +1945,13 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 3 Beschreibung"
       Erschwernis_Massnahme3_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 3 Abgeltung (max. 300 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 3 Abgeltung (max. 300 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung per Hektar"
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
+      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
        */
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1971,11 +1971,11 @@ VERSION "2020-10-26"  =
       Artenfoerderung_FF_Zielart3_Massnahme : MTEXT*1000;
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 3 Abgeltung"
       Artenfoerderung_FF_Zielart3_Abgeltung : MANDATORY 0.00 .. 100.00 [Units.CHF];
-      /** Abgeltungsart per ha oder pauschal
+      /** Abgeltungsart per Hektar oder pauschal
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltungsart"
       Artenfoerderung_Abgeltungsart : MANDATORY Abgeltungsart;
-      /** Abgeltung Artenförderung total (pauschal max 300 oder per ha max 250)
+      /** Abgeltung Artenförderung total (pauschal max 300 oder per Hektar max 250)
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -2019,9 +2019,9 @@ VERSION "2020-10-26"  =
       /** Heuen, dabei Bodenheu machen
        */
       Einstiegskriterium_Bodenheu : MANDATORY BOOLEAN;
-      /** Einstiegskriterium Abgeltung in CHF per ha
+      /** Einstiegskriterium Abgeltung in CHF per Hektar
        */
-      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung pro ha"
+      !!@ ili2db.dispName = "Einstiegskriterium Abgeltung per Hektar"
       Einstiegskriterium_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Zeigerarten gemäss Floraliste: Nährstoffzeiger (- Arten)
        */
@@ -2049,7 +2049,7 @@ VERSION "2020-10-26"  =
       EinstufungBeurteilungIstZustand_Abgeltung_Faunaliste_pauschal : MANDATORY 0.00 .. 150.00 [Units.CHF];
       !!@ ili2db.dispName = "Einstufung Beurteilung Ist-Zustand - Wiesen Kat. (Art / Typ), Grundlagen: Floraliste"
       EinstufungBeurteilungIstZustand_Wiesenkategorie : MANDATORY Wiesenkategorie;
-      /** Abgeltung Wiesenkategorie per ha (abhängig von gewählter Wiesenkategorie)
+      /** Abgeltung Wiesenkategorie per Hektar (abhängig von gewählter Wiesenkategorie)
        * 
        * Kat_RF: 0 - 0
        * Kat_RF_II: 100 - 100
@@ -2057,7 +2057,7 @@ VERSION "2020-10-26"  =
        * Kat_II_artenreicheWiese: 400 - 500
        * Kat_I_besondersartenreicheWiese: 600 - 800
        */
-      !!@ ili2db.dispName = "Wiesenkategorie Abgeltung per ha"
+      !!@ ili2db.dispName = "Wiesenkategorie Abgeltung per Hektar"
       EinstufungBeurteilungIstZustand_Wiesenkategorie_Abgeltung_ha : 0.00 .. 800.00 [Units.CHF];
       !!@ ili2db.dispName = "Exposition"
       EinstufungBeurteilungIstZustand_LageWiese_Exposition : Exposition;
@@ -2104,7 +2104,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Mähen mit Messerbalken-Mähgerät"
       BewirtschaftAbmachung_MesserbalkenMaehgeraet : MANDATORY BOOLEAN;
-      /** maximal 350 CHF pro ha/Jahr
+      /** maximal 350 CHF per Hektar/Jahr
        */
       !!@ ili2db.dispName = "Abgeltung Bewirtschaftungsabmachung"
       BewirtschaftAbmachung_Abgeltung_ha : MANDATORY 0.00 .. 350.00 [Units.CHF];
@@ -2116,9 +2116,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 1 Beschreibung"
       Erschwernis_Massnahme1_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 1 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 1 Abgeltung per Hektar"
       Erschwernis_Massnahme1_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit - Massnahme 2
        */
@@ -2128,11 +2128,11 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis 2 Beschreibung"
       Erschwernis_Massnahme2_Text : MTEXT*1000;
-      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF pro ha, pro Massnahme und auch ingesamt).
+      /** Erschwernis Massnahme 2 Abgeltung (max. 200 CHF per Hektar, per Massnahme und auch ingesamt).
        */
-      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung pro ha"
+      !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
-      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -2152,20 +2152,20 @@ VERSION "2020-10-26"  =
       Artenfoerderung_FF_Zielart3_Massnahme : MTEXT*1000;
       !!@ ili2db.dispName = "Artenförderung Fauna Zielart 3 Abgeltung"
       Artenfoerderung_FF_Zielart3_Abgeltung : MANDATORY 0.00 .. 100.00 [Units.CHF];
-      /** Abgeltungsart für Artenförderung: per ha oder pauschal
+      /** Abgeltungsart für Artenförderung: per Hektar oder pauschal
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltungsart"
       Artenfoerderung_Abgeltungsart : MANDATORY Abgeltungsart;
-      /** Abgeltung Artenförderung total (pauschal max 300 oder per ha max 250)
+      /** Abgeltung Artenförderung total (pauschal max 300 oder per Hektar max 250)
        */
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** max. 2000 CHF per ha
+      /** max. 2000 CHF per Hektar
        */
       !!@ ili2db.dispName = "Abgeltung total per Hektar"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 2000.00 [Units.CHF];
       /** Abgeltung Fläche total (Betrag x ha).
        */
-      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per ha x ha)"
+      !!@ ili2db.dispName = "Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 20000.00 [Units.CHF];
       !!@ ili2db.dispName = "Abgeltung pauschal total"
       Abgeltung_pauschal_total : MANDATORY -10000.00 .. 450.00 [Units.CHF];

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -428,8 +428,8 @@ VERSION "2020-10-26"  =
         WBL_Wiese,
         !!@ ili2db.dispName = "Obstbaumlandschaft"
         OBL,
-        !!@ ili2db.dispName = "Hostett"
-        Hostett,
+        !!@ ili2db.dispName = "Hostet"
+        Hostet,
         !!@ ili2db.dispName = "Lebhag"
         Lebhag,
         !!@ ili2db.dispName = "Hecke"

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -652,9 +652,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Strukturelemente; Abgeltung pauschal total"
       Strukturelemente_Abgeltung_pauschal_total : MANDATORY 0.00 .. 500.00 [Units.CHF];
-      /** Abgeltung total per Hektar
+      /** Abgeltung per Hektar total
        */
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1000.00 [Units.CHF];
       /** Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)
        */
@@ -780,9 +780,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Strukturelemente; Abgeltung pauschal total"
       Strukturelemente_Abgeltung_pauschal_total : MANDATORY 0.00 .. 500.00 [Units.CHF];
-      /** Abgeltung total per Hektar
+      /** Abgeltung per Hektar total
        */
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1000.00 [Units.CHF];
       /** Abgeltung Fläche total (Abgeltung per Hektar x Anzahl Hektar)
        */
@@ -991,9 +991,9 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** Abgeltung total per Hektar
+      /** Abgeltung per Hektar total
        */
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 2000.00 [Units.CHF];
       /** Abgeltung Fläche total (Betrag x ha).
        */
@@ -1268,7 +1268,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 2 Abgeltung per Hektar"
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
+      /** Erschwernis aufwendige Handarbeit Abgeltung per Hektar total
        */
       !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
@@ -1358,7 +1358,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Strukturelemente Abgeltung total (pauschal)"
       Strukturelemente_Abgeltung_total : MANDATORY 0.00 .. 2000.00 [Units.CHF];
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 700.00 [Units.CHF];
       !!@ ili2db.dispName = "Abgeltung Fläche total"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 10000.00 [Units.CHF];
@@ -1590,7 +1590,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Strukturelemente Abgeltung total (pauschal)"
       Strukturelemente_Abgeltung_total : MANDATORY 0.00 .. 1650.00 [Units.CHF];
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1800.00 [Units.CHF];
       !!@ ili2db.dispName = "Abgeltung Fläche total"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 10000.00 [Units.CHF];
@@ -1754,7 +1754,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung per Hektar"
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
+      /** Erschwernis aufwendige Handarbeit Abgeltung per Hektar total
        */
       !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -1784,7 +1784,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 750.00 [Units.CHF];
       !!@ ili2db.dispName = "Abgeltung Fläche total"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 10000.00 [Units.CHF];
@@ -1949,7 +1949,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Erschwernis Massnahme 3 Abgeltung per Hektar"
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      /** Erschwernis aufwendige Handarbeit Abgeltung total per Hektar
+      /** Erschwernis aufwendige Handarbeit Abgeltung per Hektar total
        */
       !!@ ili2db.dispName = "Erschwernis Abgeltung per Hektar total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
@@ -1979,7 +1979,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Artenförderung Abgeltung total"
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 1300.00 [Units.CHF];
       !!@ ili2db.dispName = "Abgeltung Fläche total"
       Abgeltung_flaeche_total : MANDATORY 0.00 .. 15000.00 [Units.CHF];
@@ -2161,7 +2161,7 @@ VERSION "2020-10-26"  =
       Artenfoerderung_Abgeltung_total : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** max. 2000 CHF per Hektar
        */
-      !!@ ili2db.dispName = "Abgeltung total per Hektar"
+      !!@ ili2db.dispName = "Abgeltung per Hektar total"
       Abgeltung_per_ha_total : MANDATORY 0.00 .. 2000.00 [Units.CHF];
       /** Abgeltung Fläche total (Betrag x ha).
        */

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -4,6 +4,7 @@ INTERLIS 2.3;
  * Version    | wer | Änderung
  * ------------------------------------------------------------------------------
  * 2020-10-26 | an  | Initialversion
+ * 2022-05-10 | ds  | Elliminierung Ungereimtheiten
  * ===============================================================================
  */
 !!@ technicalContact="agi@bd.so.ch"
@@ -988,8 +989,8 @@ VERSION "2020-10-26"  =
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 100.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit Massnahmen Abgeltung total (per ha).
        */
-      !!@ ili2db.dispName = "Erschwernis aufwendige Handarbeit Abgeltung per ha total"
-      Erschwernis_Massnahmen_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
+      Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Abgeltung total per Hektar
        */
       !!@ ili2db.dispName = "Abgeltung total per Hektar"
@@ -1269,7 +1270,7 @@ VERSION "2020-10-26"  =
       Erschwernis_Massnahme2_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
        */
-      !!@ ili2db.dispName = "Erschwernis aufwendige Handarbeit Abgeltung total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 200.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1755,7 +1756,7 @@ VERSION "2020-10-26"  =
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
        */
-      !!@ ili2db.dispName = "Erschwernis aufwendige Handarbeit Abgeltung total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;
@@ -1950,7 +1951,7 @@ VERSION "2020-10-26"  =
       Erschwernis_Massnahme3_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       /** Erschwernis aufwendige Handarbeit Abgeltung total per ha
        */
-      !!@ ili2db.dispName = "Erschwernis aufwendige Handarbeit Abgeltung total"
+      !!@ ili2db.dispName = "Erschwernis Abgeltung per ha total"
       Erschwernis_Abgeltung_ha : MANDATORY 0.00 .. 300.00 [Units.CHF];
       !!@ ili2db.dispName = "Artenförderung Fauna oder Flora Zielart 1"
       Artenfoerderung_FF_Zielart1 : TEXT*255;

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -1069,9 +1069,10 @@ VERSION "2020-10-26"  =
     !!@ ili2db.dispName = "Beurteilung Obstbaumlandschaft"
     CLASS Beurteilung_OBL
     EXTENDS Beurteilung =
-      /** Einstiegskriterien Hostet sind alle erfüllt. Details siehe Zusatz Blatt Leistungen.
+      /** Einstiegskriterien Obstbaumlandschaft sind alle erfüllt. Details siehe Zusatz Blatt Leistungen.
        */
-      Einstiegskriterium_Hostet : MANDATORY BOOLEAN;
+      !!@ ili2db.dispName = "Einstiegskriterien Obstbaumlandschaft erfüllt"
+      Einstiegskriterium_OBL : MANDATORY BOOLEAN;
       /** Beitragsberechnung gemäss Zusatzdokument vom
        */
       !!@ ili2db.dispName = "Zusatzdokument vom"


### PR DESCRIPTION
Grössere Änderung sind:
- Umbenennung des Attributs `Beurteilung_Hecke.Erschwernis_Massnahmen_Abgeltung_ha` zum einheitlichen  `Beurteilung_Hecke.Erschwernis_Abgeltung_ha`.
- Umbenennungvon falschem `Beurteilung_OBL.Einstiegskriterium_Hostet` zu `Beurteilung_OBL.Einstiegskriterium_OBL`
- Umbenennung der `Vereinbarungsart.Hostett` zu `Vereinbarungsart.Hostet` weil "Hostett" (mit zwei t) nicht benutzt werden soll.

Ansonsten enthält dieser PR einige Anpassungen der Metaattribute für den `dispName` und die Kommentare betreffend dem Wort "per" vs "pro" und "ha" vs "Hektar" etc.