### PR TITLE
[SO_ARP_MJPNL_20201026] Attribute für Pauschalen

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -566,8 +566,12 @@ VERSION "2020-10-26"  =
       Betrag_Flaeche : MANDATORY 0.00 .. 100000.00[Units.CHF];
       !!@ ili2db.dispName = "Total der Abgeltungen für die Bäume total"
       Betrag_Baeume : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
-      !!@ ili2db.dispName = "Total der pauschalen Abgeltungen"
-      Betrag_Pauschal : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
+      !!@ ili2db.dispName = "Total der pauschalen regulären Abgeltungen"
+      Betrag_Pauschal_Regulaer : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
+      !!@ ili2db.dispName = "Total der pauschalen einmaligen Abgeltungen (bereits ausbezahlt)"
+      Betrag_Pauschal_Einmalig_Ausbezahlt : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
+      !!@ ili2db.dispName = "Total der pauschalen einmaligen Abgeltungen (freigegeben)"
+      Betrag_Pauschal_Einmalig_Freigegeben : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
       !!@ ili2db.dispName = "Gesamtbetrag"
       Gesamtbetrag : MANDATORY -100000.00 .. 100000.00 [Units.CHF];
       !!@ ili2db.dispName = "Jahr der Auszahlung"


### PR DESCRIPTION
Einzelne Attribute in Abrechnung_per_Vereinbarung für Totalbeträge der einmaligen Pauschalen (ausbezahlt und freigegeben).