### PR TITLE
[SO_ARP_MJPNL_20201026] Erlaube 0 Parents für AbrechnungPerLeistung 

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -2389,12 +2389,12 @@ VERSION "2020-10-26"  =
 
     ASSOCIATION AbrechnungLeistung_AbrechnungPerVereinbarung =
       AbrechnungLeistung -- {1..*} Abrechnung_per_Leistung;
-      AbrechnungPerVereinbarung -<#> {1} Abrechnung_per_Vereinbarung;
+      AbrechnungPerVereinbarung -- {0..1} Abrechnung_per_Vereinbarung;
     END AbrechnungLeistung_AbrechnungPerVereinbarung;
 
     ASSOCIATION AbrechnungPerVereinbarung_AbrechnungPerBewirtschafter =
       AbrechnungPerVereinbarung -- {1..*} Abrechnung_per_Vereinbarung;
-      AbrechnungPerBewirtschafter -<#> {1} Abrechnung_per_Bewirtschafter;
+      AbrechnungPerBewirtschafter -- {0..1} Abrechnung_per_Bewirtschafter;
     END AbrechnungPerVereinbarung_AbrechnungPerBewirtschafter;
 
     ASSOCIATION Basisvertrag_Berater =


### PR DESCRIPTION
...und AbrechnungPerBewirtschafter um Leistungen ohne Zusammenzug zu ermöglichen