### PR TITLE
[SO_ARP_MJPNL_20201026] Gelan Update Requirements und Fixes

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -2323,7 +2323,7 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Übersteuerung GELAN Bewirtschafter"
       Uebersteuerung_Bewirtschafter : MANDATORY BOOLEAN;
-      /** Ob die BewE_ID nach GELAN update überprüft wurde, also die Vereinbarung wieder berücksichtigt werden kann.
+      /** Ob der Wechsel der BewE_ID nach GELAN update überprüft wurde, also die Vereinbarung wieder berücksichtigt werden kann.
        */
       !!@ ili2db.dispName = "Bewirtschaftungseinheit überprüft"
       BewE_ID_geprueft : MANDATORY BOOLEAN;

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -2323,6 +2323,10 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Übersteuerung GELAN Bewirtschafter"
       Uebersteuerung_Bewirtschafter : MANDATORY BOOLEAN;
+      /** Ob die BewE_ID nach GELAN update überprüft wurde, also die Vereinbarung wieder berücksichtigt werden kann.
+       */
+      !!@ ili2db.dispName = "Bewirtschaftungseinheit überprüft"
+      BewE_ID_geprueft : MANDATORY BOOLEAN;
       /** Wird automatisch abgefüllt von Gemeindetabelle. Kann mehrere Gemeinden (BFS-Nr) betreffen (Array of Integer)
        */
       !!@ ili2db.dispName = "BFS-Nr"

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -561,7 +561,7 @@ VERSION "2020-10-26"  =
       Flaeche : MANDATORY 0.01 .. 1000000.00 [Units.ha];
       /** Falls es sich um eine Anzahl Bäume handelt*/
       !!@ ili2db.dispName = "Anzahl Bäume"
-      Anzahl_Baeume : MANDATORY 0 .. 1000;
+      Anzahl_Baeume : MANDATORY 0 .. 100000;
       !!@ ili2db.dispName = "Total der Abgeltungen für die Fläche"
       Betrag_Flaeche : MANDATORY 0.00 .. 100000.00[Units.CHF];
       !!@ ili2db.dispName = "Total der Abgeltungen für die Bäume total"
@@ -1638,7 +1638,7 @@ VERSION "2020-10-26"  =
       /** Strukturelemente Gewässer Abgeltung (pauschal in CHF) bis 400 CHF.
        */
       !!@ ili2db.dispName = "Gewässer Abgeltung"
-      Strukturelemente_Gewaesser_Abgeltung : 0.00 .. 400.00 [Units.CHF];
+      Strukturelemente_Gewaesser_Abgeltung : MANDATORY 0.00 .. 400.00 [Units.CHF];
       /** Strukturelemente - Hochstaudenfluren, Grossseggenriede und / oder Röhrichte
        */
       !!@ ili2db.dispName = "Hochstaudenfluren, Grossseggenriede und / oder Röhrichte"
@@ -1893,7 +1893,7 @@ VERSION "2020-10-26"  =
       /** Mindestfläche von 50 Aren (in der Regel); Ausnahme bei Arrondierungen oder angrenzend an einen anderen Programmtyp; keine Flächenbegrenzung bei Objekten von nationaler Bedeutung oder zur spezifischen Artenförderung.
        */
       !!@ ili2db.dispName = "Einstiegskriterium Mindestfläche"
-      Einstiegskriterium_Mindestflaeche : BOOLEAN;
+      Einstiegskriterium_Mindestflaeche : MANDATORY BOOLEAN;
       /** Einstiegskriterium Keine Zufütterung
        */
       !!@ ili2db.dispName = "Einstiegskriterium Keine Zufütterung"


### PR DESCRIPTION
### Gelan Update Requirements
Bei einem GELAN Abgleich soll in der Vereinbarung geprüft werden, ob die GELAN Person der Bewe-ID gewechselt hat und wenn ja, die Vereinbarungen dieser Bewe-ID auf einen Status setzen.

Damit wir den Ursprungstatus nicht verlieren, wird der Status nicht verändert, sondern ein Boolean gesetzt: werden.

`beweid_geprueft=false`

Deshalb neues Feld in Vereinbarung `BewE_ID_geprueft`

### Fixes
- Fehlende Mandatory Felder
- Anzahl_Baeume war zu gering in `Abrechnung_per_Vereinbarung`
