### PR TITLE
[SO_ARP_MJPNL_20201026] Historie Bewirtschafter Vereinbarung

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -456,7 +456,7 @@ VERSION "2020-10-26"  =
       /** Optionales Änderungsdatum des Dokuments. Wird vom System automatisch vergeben.
        */
       !!@ ili2db.dispName = "Änderungsdatum"
-      Aenderungsdatum : FORMAT INTERLIS.XMLDate "1900-1-1" .. "2100-12-31";
+      Aenderungszeitpunkt : FORMAT INTERLIS.XMLDate "1900-1-1" .. "2100-12-31";
       /** Person die das Dokument geändert hat. Wird vom System automatisch verwaltet.
        */
       !!@ ili2db.dispName = "Operator Änderung"
@@ -479,7 +479,7 @@ VERSION "2020-10-26"  =
       !!@ ili2db.dispName = "Jahr des neuen Bewirtschafters"
       Jahr_Bewirtschafterwechsel : MANDATORY 1900 .. 2100;
       !!@ ili2db.dispName = "Änderungsdatum"
-      Aenderungsdatum : FORMAT INTERLIS.XMLDate "1900-1-1" .. "2100-12-31";
+      Aenderungsdatum : INTERLIS.XMLDateTime;
     END Vereinbarung_Bewirtschafter_Historie;
 
     DOMAIN

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -478,6 +478,8 @@ VERSION "2020-10-26"  =
        */
       !!@ ili2db.dispName = "Jahr des neuen Bewirtschafters"
       Jahr_Bewirtschafterwechsel : MANDATORY 1900 .. 2100;
+      !!@ ili2db.dispName = "Änderungsdatum"
+      Aenderungsdatum : FORMAT INTERLIS.XMLDate "1900-1-1" .. "2100-12-31";
     END Vereinbarung_Bewirtschafter_Historie;
 
     DOMAIN


### PR DESCRIPTION
- Aendrungszeitpunkt in `Vereinbarung_Bewirtschafter_Historie`, um Eindeutigkeit zu gewährleisten bei mehrfachem Wechsel (auch versehentlich) pro Jahr