### PR TITLE
[SO_ARP_MJPNL20201026] Associaton Stärken und Kardinalitäten

### DIFF
--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -2305,7 +2305,7 @@ VERSION "2020-10-26"  =
     END Strukturelement_Punkt;
 
     ASSOCIATION Berater_Beurteilung =
-      Berater -- {1} Berater;
+      Berater -- {0..1} Berater;
       Beurteilung -- {0..*} Beurteilung;
     END Berater_Beurteilung;
 
@@ -2414,7 +2414,7 @@ VERSION "2020-10-26"  =
 
     ASSOCIATION Basisvertrag_Berater =
       Basisvertrag -- {0..*} Basisvertrag;
-      Berater -- {1} Berater;
+      Berater -- {0..1} Berater;
     END Basisvertrag_Berater;
 
     ASSOCIATION Beobachtung_Fauna =
@@ -2457,17 +2457,17 @@ VERSION "2020-10-26"  =
 
     ASSOCIATION AbrechnungLeistung_Vereinbarung =
       Leistungsabrechnung -- {0..*} Abrechnung_per_Leistung;
-      Vereinbarung -<#> {1} Vereinbarung;
+      Vereinbarung -- {0..1} Vereinbarung;
     END AbrechnungLeistung_Vereinbarung;
 
     ASSOCIATION AbrechnungPerVereinbarung_Vereinbarung =
       AbrechnungPerVereinbarung -- {0..*} Abrechnung_per_Vereinbarung;
-      Vereinbarung -<#> {1} Vereinbarung;
+      Vereinbarung -- {0..1} Vereinbarung;
     END AbrechnungPerVereinbarung_Vereinbarung;
 
     ASSOCIATION Beurteilung_Vereinbarung =
       Beurteilung -- {0..*} Beurteilung;
-      Vereinbarung -- {1} Vereinbarung;
+      Vereinbarung -<#> {1} Vereinbarung;
     END Beurteilung_Vereinbarung;
 
     ASSOCIATION Strukturelement_Flaeche_Vereinbarung =
@@ -2494,7 +2494,7 @@ VERSION "2020-10-26"  =
      */
     ASSOCIATION Vereinbarung_UZL_Subregion =
       Vereinbarung -- {0..*} Vereinbarung;
-      UZL_Subregion (EXTERNAL) -- {1} SO_ARP_MJPNL_20201026.Umweltziele.UZL_Subregion;
+      UZL_Subregion (EXTERNAL) -- {0..1} SO_ARP_MJPNL_20201026.Umweltziele.UZL_Subregion;
     END Vereinbarung_UZL_Subregion;
 
   END MJPNL;

--- a/models/ARP/SO_ARP_MJPNL_20201026.ili
+++ b/models/ARP/SO_ARP_MJPNL_20201026.ili
@@ -2467,7 +2467,7 @@ VERSION "2020-10-26"  =
 
     ASSOCIATION Beurteilung_Vereinbarung =
       Beurteilung -- {0..*} Beurteilung;
-      Vereinbarung -<#> {1} Vereinbarung;
+      Vereinbarung -- {1} Vereinbarung;
     END Beurteilung_Vereinbarung;
 
     ASSOCIATION Strukturelement_Flaeche_Vereinbarung =


### PR DESCRIPTION
 Abrechnungstabellen sollen nicht abhängig von Vereinbarungen sein, da sie sonst nicht mehr in der Historisierung verfügbar sind, wenn eine Vereinbarung gelöscht wird.

~Hingegen sollen Beurteilungen stärker an Vereinbarungen geknüpft sein: Als Compositions.~