### PR TITLE
[awjf_rodung_rodungsersatz] Korrektur Attribut Dokumente

### DIFF
--- a/models/AWJF/SO_AWJF_Rodung_Rodungsersatz_Publikation_20241008.ili
+++ b/models/AWJF/SO_AWJF_Rodung_Rodungsersatz_Publikation_20241008.ili
@@ -329,6 +329,9 @@ VERSION "2023-10-08"  =
       /** Bemerkung zur Geometrie
        */
       Bemerkung_Geometrie : MTEXT;
+      /** Verweise auf Dokumente (RRB, Gesuche, Pläne, ...)
+       */
+      !!@ ili2db.mapping=JSON
       Dokumente : BAG {0..*} OF SO_AWJF_Rodung_Rodungsersatz_Publikation_20241008.Rodungsvorhaben.Dokument;
     END Rodungsdaten;
 


### PR DESCRIPTION
ili2db.mapping JSON fehlte noch in den Metaattributen