### PR TITLE
[alw validierung drainage] Update Validierungsmodell 20250311

### DIFF
--- a/models/ALW/VSADSSMINI_2020_LV95_Validierung_Drainage_20250311.ili
+++ b/models/ALW/VSADSSMINI_2020_LV95_Validierung_Drainage_20250311.ili
@@ -2,7 +2,7 @@ INTERLIS 2.3;
 
 CONTRACTED MODEL VSADSSMINI_2020_LV95_Validierung_Drainage_20250311 (de)
 AT "https://geo.so.ch"
-VERSION "2025-03-11"  =
+VERSION "2025-03-20"  =
   
 IMPORTS SIA405_Base_Abwasser_LV95;
 IMPORTS VSADSSMINI_2020_LV95;
@@ -56,6 +56,7 @@ IMPORTS UNQUALIFIED INTERLIS;
      */
     VIEW v_Drainageleitung
       PROJECTION OF L ~ VSADSSMINI_2020_LV95.VSADSSMini.Leitung;
+      WHERE DEFINED(L->FunktionHierarchisch) AND DEFINED(L->FunktionHydraulisch) AND DEFINED(L->Nutzungsart_Ist);
       WHERE L->FunktionHierarchisch == #SAA.andere;
       WHERE L->FunktionHydraulisch == #Sickerleitung
         OR L->FunktionHydraulisch == #Drainagetransportleitung


### PR DESCRIPTION
Nur Objekte mit vollständigen Attributen (FunktionHierarchisch, FunktionHydraulisch, Nutzungsart_Ist) gemäss Mindestanforderung ALW Regel 101 sind erlaubt.

In der WHERE-Bedingung für die VIEW muss sichergestellt sein, dass die 3 verwendeten Attribute definiert sind, ansonsten kommt es zu unerwarteten Fehlermeldungen. Falls die 3 Attribute nicht definiert sind, so wird davon ausgegangen, dass das Leitungsobjekt zur Siedlungsentwässerung gehört und für das Drainagenetz nicht relevant ist.

Es findet _keine_ Anpassung des Modellnamens statt, die Konfigurationsdateien müssen also nicht angepasst werden.