### PR TITLE
[AFU VSADSSMINI_2020 Validierung 20250123] Aktualisierte Validerungsmodelle IPW

### DIFF
--- a/models/AFU/VSADSSMINI_2020_1_LV95_Validierung_IPW_S1_20250123.ili
+++ b/models/AFU/VSADSSMINI_2020_1_LV95_Validierung_IPW_S1_20250123.ili
@@ -2,7 +2,7 @@ INTERLIS 2.3;
 
 CONTRACTED MODEL VSADSSMINI_2020_1_LV95_Validierung_IPW_S1_20250123 (de)
 AT "https://geo.so.ch"
-VERSION "2025-01-31" =
+VERSION "2025-04-08" =
   
 IMPORTS SIA405_Base_Abwasser_LV95;
 IMPORTS VSADSSMINI_2020_1_LV95;
@@ -26,7 +26,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 11102
       !!@ ilivalid.msg = "Knoten: weniger als 90% Status erfasst"
-      CONSTRAINT >= 90% DEFINED(Status) OR Funktion == #Leitungsknoten;
+      CONSTRAINT >= 90% DEFINED(Status) AND Funktion != #Leitungsknoten;
 
     END v_Knoten;
 
@@ -36,9 +36,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF K;
 
-      !!@ name = 11006
+      !!@ name = 11006a
       !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung);
+
+      !!@ name = 11006b
+      !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE Bezeichnung;
 
       !!@ name = 11012
       !!@ ilivalid.msg = "Knoten: Attribut 'Finanzierung' ist obligatorisch."
@@ -54,7 +58,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 11101
       !!@ ilivalid.msg = "Knoten: weniger als 80% Finanzierung erfasst"
-      CONSTRAINT >= 80% DEFINED(Finanzierung) OR Funktion == #Leitungsknoten;
+      CONSTRAINT >= 80% DEFINED(Finanzierung) AND Funktion != #Leitungsknoten;
 
     END v_Knoten_inBetrieb;
 
@@ -83,9 +87,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF L;
 
-      !!@ name = 12005
+      !!@ name = 12005a
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung) OR isEnumSubVal(FunktionHierarchisch, #SAA);
+
+      !!@ name = 12005b
+      !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE WHERE isEnumSubVal(FunktionHierarchisch, #PAA): Bezeichnung, DatenherrRef;
 
       !!@ name = 12007
       !!@ ilivalid.msg = "Leitung: Attribut 'Finanzierung' ist obligatorisch."
@@ -108,8 +116,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       MANDATORY CONSTRAINT INTERLIS.objectCount(Knoten_vonRef) == 1 OR isEnumSubVal(FunktionHierarchisch,#SAA);
 
       !!@ name = 12025
-      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch und darf nicht /unbekannt/ sein."
-      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch."
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist);
 
       !!@ name = 12101
       !!@ ilivalid.msg = "Leitung: weniger als 80% Finanzierung erfasst"
@@ -117,7 +125,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 12102
       !!@ ilivalid.msg = "Leitung: weniger als 90% Nutzungsart_Ist erfasst"
-      CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist);
 
     END v_Leitung_inBetrieb;
 

--- a/models/AFU/VSADSSMINI_2020_1_LV95_Validierung_IPW_S2_20250123.ili
+++ b/models/AFU/VSADSSMINI_2020_1_LV95_Validierung_IPW_S2_20250123.ili
@@ -2,7 +2,7 @@ INTERLIS 2.3;
 
 CONTRACTED MODEL VSADSSMINI_2020_1_LV95_Validierung_IPW_S2_20250123 (de)
 AT "https://geo.so.ch"
-VERSION "2025-01-31" =
+VERSION "2025-04-08" =
   
 IMPORTS SIA405_Base_Abwasser_LV95;
 IMPORTS VSADSSMINI_2020_1_LV95;
@@ -83,9 +83,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       !!@ ilivalid.msg = "Knoten (PAA): Attribut 'Betreiber (BetreiberRef)' fehlt."
       MANDATORY CONSTRAINT DEFINED(BetreiberRef) OR FunktionHierarchisch == #SAA OR Funktion == #Leitungsknoten;
 
-      !!@ name = 11006
+      !!@ name = 11006a
       !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung);
+
+      !!@ name = 11006b
+      !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE Bezeichnung;
 
       !!@ name = 11007
       !!@ ilivalid.msg = "Knoten (PAA): Attribut 'Deckelkote' fehlt."
@@ -208,9 +212,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Betreiber (BetreiberRef)' fehlt."
       MANDATORY CONSTRAINT DEFINED(BetreiberRef) OR isEnumSubVal(FunktionHierarchisch, #SAA);
 
-      !!@ name = 12005
+      !!@ name = 12005a
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung) OR isEnumSubVal(FunktionHierarchisch, #SAA);
+
+      !!@ name = 12005b
+      !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE WHERE isEnumSubVal(FunktionHierarchisch, #PAA): Bezeichnung, DatenherrRef;
 
       !!@ name = 12007
       !!@ ilivalid.msg = "Leitung: Attribut 'Finanzierung' ist obligatorisch."
@@ -261,8 +269,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       MANDATORY CONSTRAINT DEFINED(Nutzungsart_geplant) AND Nutzungsart_geplant != #unbekannt;
 
       !!@ name = 12025
-      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch und darf nicht /unbekannt/ sein."
-      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch."
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist);
 
       !!@ name = 12030
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Profiltyp' ist obligatorisch."

--- a/models/AFU/VSADSSMINI_2020_LV95_Validierung_IPW_S1_20250123.ili
+++ b/models/AFU/VSADSSMINI_2020_LV95_Validierung_IPW_S1_20250123.ili
@@ -2,7 +2,7 @@ INTERLIS 2.3;
 
 CONTRACTED MODEL VSADSSMINI_2020_LV95_Validierung_IPW_S1_20250123 (de)
 AT "https://geo.so.ch"
-VERSION "2025-01-31" =
+VERSION "2025-04-08" =
   
 IMPORTS SIA405_Base_Abwasser_LV95;
 IMPORTS VSADSSMINI_2020_LV95;
@@ -26,7 +26,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 11102
       !!@ ilivalid.msg = "Knoten: weniger als 90% Status erfasst"
-      CONSTRAINT >= 90% DEFINED(Status) OR Funktion == #Leitungsknoten;
+      CONSTRAINT >= 90% DEFINED(Status) AND Funktion != #Leitungsknoten;
 
     END v_Knoten;
 
@@ -36,9 +36,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF K;
 
-      !!@ name = 11006
+      !!@ name = 11006a
       !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung);
+
+      !!@ name = 11006b
+      !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE Bezeichnung;
 
       !!@ name = 11012
       !!@ ilivalid.msg = "Knoten: Attribut 'Finanzierung' ist obligatorisch."
@@ -54,7 +58,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 11101
       !!@ ilivalid.msg = "Knoten: weniger als 80% Finanzierung erfasst"
-      CONSTRAINT >= 80% DEFINED(Finanzierung) OR Funktion == #Leitungsknoten;
+      CONSTRAINT >= 80% DEFINED(Finanzierung) AND Funktion != #Leitungsknoten;
 
     END v_Knoten_inBetrieb;
 
@@ -83,9 +87,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF L;
 
-      !!@ name = 12005
+      !!@ name = 12005a
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung) OR isEnumSubVal(FunktionHierarchisch, #SAA);
+
+      !!@ name = 12005b
+      !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE WHERE isEnumSubVal(FunktionHierarchisch, #PAA): Bezeichnung, DatenherrRef;
 
       !!@ name = 12007
       !!@ ilivalid.msg = "Leitung: Attribut 'Finanzierung' ist obligatorisch."
@@ -108,8 +116,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       MANDATORY CONSTRAINT INTERLIS.objectCount(Knoten_vonRef) == 1 OR isEnumSubVal(FunktionHierarchisch,#SAA);
 
       !!@ name = 12025
-      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch und darf nicht /unbekannt/ sein."
-      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch."
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist);
 
       !!@ name = 12101
       !!@ ilivalid.msg = "Leitung: weniger als 80% Finanzierung erfasst"
@@ -117,7 +125,7 @@ IMPORTS UNQUALIFIED INTERLIS;
 
       !!@ name = 12102
       !!@ ilivalid.msg = "Leitung: weniger als 90% Nutzungsart_Ist erfasst"
-      CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist);
 
     END v_Leitung_inBetrieb;
 

--- a/models/AFU/VSADSSMINI_2020_LV95_Validierung_IPW_S2_20250123.ili
+++ b/models/AFU/VSADSSMINI_2020_LV95_Validierung_IPW_S2_20250123.ili
@@ -2,7 +2,7 @@ INTERLIS 2.3;
 
 CONTRACTED MODEL VSADSSMINI_2020_LV95_Validierung_IPW_S2_20250123 (de)
 AT "https://geo.so.ch"
-VERSION "2025-01-31" =
+VERSION "2025-04-08" =
   
 IMPORTS SIA405_Base_Abwasser_LV95;
 IMPORTS VSADSSMINI_2020_LV95;
@@ -83,9 +83,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       !!@ ilivalid.msg = "Knoten (PAA): Attribut 'Betreiber (BetreiberRef)' fehlt."
       MANDATORY CONSTRAINT DEFINED(BetreiberRef) OR FunktionHierarchisch == #SAA OR Funktion == #Leitungsknoten;
 
-      !!@ name = 11006
+      !!@ name = 11006a
       !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung);
+
+      !!@ name = 11006b
+      !!@ ilivalid.msg = "Knoten: Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE Bezeichnung;
 
       !!@ name = 11007
       !!@ ilivalid.msg = "Knoten (PAA): Attribut 'Deckelkote' fehlt."
@@ -208,9 +212,13 @@ IMPORTS UNQUALIFIED INTERLIS;
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Betreiber (BetreiberRef)' fehlt."
       MANDATORY CONSTRAINT DEFINED(BetreiberRef) OR isEnumSubVal(FunktionHierarchisch, #SAA);
 
-      !!@ name = 12005
+      !!@ name = 12005a
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist obligatorisch."
       MANDATORY CONSTRAINT DEFINED(Bezeichnung) OR isEnumSubVal(FunktionHierarchisch, #SAA);
+
+      !!@ name = 12005b
+      !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Bezeichnung' ist nicht eindeutig."
+      UNIQUE WHERE isEnumSubVal(FunktionHierarchisch, #PAA): Bezeichnung, DatenherrRef;
 
       !!@ name = 12007
       !!@ ilivalid.msg = "Leitung: Attribut 'Finanzierung' ist obligatorisch."
@@ -261,8 +269,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       MANDATORY CONSTRAINT DEFINED(Nutzungsart_geplant) AND Nutzungsart_geplant != #unbekannt;
 
       !!@ name = 12025
-      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch und darf nicht /unbekannt/ sein."
-      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+      !!@ ilivalid.msg = "Leitung: Attribut 'Nutzungsart_Ist' ist obligatorisch."
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist);
 
       !!@ name = 12030
       !!@ ilivalid.msg = "Leitung (PAA): Attribut 'Profiltyp' ist obligatorisch."


### PR DESCRIPTION
nur kleine Änderung an den Validierungsmodellen:

- Plausibilitäts-Constraints mit AND statt OR
- in config deaktivierte UNIQUE Constraints in Validierungsmodellen reaktiviert
- Korrektur Constraints zu Nutzungsart_Ist (Wert /unbekannt/ erlauben)

Auswirkungen:
- minor changes: keine Anpassung der Modellnamen
- keine Anpassung an meta-config nötig