### PR TITLE
[awjf_waldplan] Korrektur Schreibfehler

### DIFF
--- a/models/AWJF/SO_AWJF_Waldplan_20250312.ili
+++ b/models/AWJF/SO_AWJF_Waldplan_20250312.ili
@@ -185,7 +185,7 @@ VERSION "2025-03-12"  =
        */
       Wirtschaftszone : (
         Jura,
-        Mitellland
+        Mittelland
       );
       /** Befindet sich der Wald auf dem Grundstück im Besitz einer ausserkantonalen Einwohnergemeinde, Bürgergemeinde oder Einheitsgemeinde?
        */

--- a/models/AWJF/SO_AWJF_Waldplan_Publikation_20250312.ili
+++ b/models/AWJF/SO_AWJF_Waldplan_Publikation_20250312.ili
@@ -280,7 +280,7 @@ VERSION "2025-03-12"  =
        */
       Wirtschaftszone : (
         Jura,
-        Mitellland
+        Mittelland
       );
       /** Grundbuchnummer
        */


### PR DESCRIPTION
Der Wert Mittelland für das Attribut Wirtschaftszone war falsch geschrieben.