### PR TITLE
[afu_bootsanbindeplaetze] Korrektur Strukturklasse

### DIFF
--- a/models/AFU/SO_AFU_Bootsanbindeplaetze_Publikation_20250604.ili
+++ b/models/AFU/SO_AFU_Bootsanbindeplaetze_Publikation_20250604.ili
@@ -133,19 +133,19 @@ VERSION "2025-06-04"  =
       /** Verweise auf Personendokumente
        */
       !!@ ili2db.mapping=JSON
-      Dokumente : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Dokument;
+      Dokumente :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Dokument;
       /** Angaben zum Mieter / zur Mieterin
        */
       !!@ ili2db.mapping=JSON
-      Nutzer : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
+      Nutzer :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
       /** Rechnungsstelle für die Nutzungsgebühr
        */
       !!@ ili2db.dispName="Rechungsstelle Nutzungsgebühr"
-      Rechnungsstelle_Nutzungsgebuehr : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
+      Rechnungsstelle_Nutzungsgebuehr :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
       /** Rechnungsstelle für die Steggebühr
        */
       !!@ ili2db.dispName="Rechnungsstelle Steggebühr"
-      Rechnungsstelle_Steggebuehr : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
+      Rechnungsstelle_Steggebuehr :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
       /** Beanspruchte Wasserfläche des Schiffsstegs in m2 für diesen Bootsanbindeplatz. Pro beanspruchte m2 Wasserfläche wird 6 Fr. verrechnet (minimum 60 Fr.).
        */
       !!@ ili2db.dispName="Fläche Schiffsteg"
@@ -180,14 +180,14 @@ VERSION "2025-06-04"  =
       /** Verweise auf Dokumente zum Hauptstandort
        */
       !!@ ili2db.mapping=JSON
-      Dokumente : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Dokument;
+      Dokumente :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Dokument;
       /** Befindet sich der Standort in Privatbesitz?
        */
       Privatvermietung : MANDATORY BOOLEAN;
       /** EigentümerIn des Standortes
        */
       !!@ ili2db.dispName="EigentümerIn"
-      EigentuemerIn : SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
+      EigentuemerIn :  BAG {0..*} OF SO_AFU_Bootsanbindeplaetze_Publikation_20250604.Bootsanbindeplaetze.Kontaktdaten;
       /** Total beanspruchte Wasserfläche des Schiffsstegs am Standort in m2.
        */
       !!@ ili2db.dispName="Gesamte Fläche Schiffsteg"


### PR DESCRIPTION
Es fehlte BAG of bei der Verwendung der Strukturklassen im ili-Modell.