### PR TITLE
[afu_bodenschadstoffe] Neue View-Attribute

### DIFF
--- a/models/AFU/SO_AFU_Verzeichnis_schadstoffbelastete_Boeden_Publikation_20260505.ili
+++ b/models/AFU/SO_AFU_Verzeichnis_schadstoffbelastete_Boeden_Publikation_20260505.ili
@@ -9,7 +9,7 @@ INTERLIS 2.3;
  * !! 2020-06-22| Andrea Lüscher | Anpassung Rückmeldung durch AFU aus der Testphase
  * !! 2020-07-01| Andrea Lüscher | Attribut "...inaktiv" heisst neu "aus_vsb_entlassen"
  * !! 2020-08-03| Andrea Lüscher | Verdachtsstreifenbreite 0_m und keine_Angabe entfernt
- * !! 2026-05-05| Patrick Bur    | Zusätzliches Aufzählelement 8_m Radius, neue Klasse PFAS, neue Attribute Flaeche und Umfang
+ * !! 2026-05-05| Patrick Bur    | Zusätzliches Aufzählelement 8_m Radius, neue Klasse PFAS, neue Attribute für View-Ersatz
  * !!==================================================================================================
  */
 !!@ technicalContact=mailto:agi@bd.so.ch
@@ -105,6 +105,21 @@ VERSION "2026-05-05"  =
      */
     Flurnamen : MANDATORY TEXT*10000;
     Nutzungsverbot : MANDATORY BOOLEAN;
+    /** Öffentliche Bezeichnung des Trennkriteriums
+     */
+    Trennkriterium_oeffentlich : TEXT*255;
+    /** Öffentliche Bezeichnung der Belastungsstufe
+     */
+    Belastungsstufe_oeffentlich : TEXT*255;
+    /** Öffentliche Bezeichnung der Belastungsursache
+     */
+    Belastungsursache_oeffentlich : TEXT*255;
+    /** Öffentliche Bezeichnung der Ausdehnung
+     */
+    Ausdehnung_oeffentlich : TEXT*255;
+    /** Öffentliche Bezeichnung des Typs
+     */
+    Typ_oeffentlich : TEXT*255;
   END schadstoffbelasteter_Boden;
 
   CLASS Flaeche (ABSTRACT)


### PR DESCRIPTION
Bisher wurden über Views neue Attribute generiert, welche in erster Linie für die öffentlichen WebGIS-Layers verwendet wurden. Damit zukünfti Row-Filter für die Views möglich sind, wurden diese Attribute (mit dem Zusatz _oeffentlich) direkt in das Modell in die abstrakte Klasse schadstoffbelasteter_Boden integriert. Sie sind nicht mandatory, da nicht jede Klasse immer alle Attribute verwendet.