### PR TITLE
[afu_bodenschadstoffe] changed class Pruefperimeter_Bodenabtrag

### DIFF
--- a/models/AFU/SO_AFU_Verzeichnis_schadstoffbelastete_Boeden_Publikation_20260505.ili
+++ b/models/AFU/SO_AFU_Verzeichnis_schadstoffbelastete_Boeden_Publikation_20260505.ili
@@ -675,13 +675,30 @@ VERSION "2026-05-05"  =
       Vermutete_Quelle : TEXT*200;
     END PFAS;
 
-    /** Aggregierte Verdachtsflächen
+    /** Aggregierte Verdachtsflächen aus allen Teilbereichen
      */
-    CLASS Pruefperimeter_Bodenabtrag
-    EXTENDS SO_AFU_Verzeichnis_schadstoffbelastete_Boeden_Publikation_20260505.Flaeche =
+    CLASS Pruefperimeter_Bodenabtrag =
+      /** Status
+       */
+      Status : (
+        !!@ ili2db.dispName="Verdachtsfläche"
+        Verdachtsflaeche,
+        !!@ ili2db.dispName="Belastung nachgewiesen"
+        Belastung_nachgewiesen
+      );
+      /** Ist die Flaeche aktiv?
+       */
+      aktiv : BOOLEAN;
+      /** Wurden Nutzungseinschränkungen verfügt?
+       */
+      Nutzungseinschraenkung : BOOLEAN;
+      Nutzungsverbot : BOOLEAN;
       /** Öffentliche Bezeichnung des Flächentyps
        */
       Typ : TEXT*255;
+      /** Geometrie der Flaeche
+       */
+      Geometrie : MANDATORY GeometryCHLV95_V1.MultiSurface;
     END Pruefperimeter_Bodenabtrag;
 
   END schadstoffbelastete_Boeden;


### PR DESCRIPTION
Die Klasse benötigt wesentlich weniger Attribute, als durch das Extend zustande kommen, daher ist es effizienter die paar benötigten Attribute einzeln aufzuführen.